### PR TITLE
Fix missing dependencies during compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV packetver ${packetver}
 ENV version ${version}
 
 # install dependent packages, secure mysql, and download rathena source
-RUN (echo "mysql-server mysql-server/root_password password default" | debconf-set-selections) && (echo "mysql-server mysql-server/root_password_again password default" | debconf-set-selections) && apt-get update && apt-get upgrade -yq && apt-get install --no-install-recommends -yq git make gcc libmysqlclient-dev zlib1g-dev libpcre3-dev mysql-server libmysqlclient-dev ca-certificates
+RUN (echo "mysql-server mysql-server/root_password password default" | debconf-set-selections) && (echo "mysql-server mysql-server/root_password_again password default" | debconf-set-selections) && apt-get update && apt-get upgrade -yq && apt-get install --no-install-recommends -yq git make gcc g++ libmysqlclient-dev zlib1g-dev libpcre3-dev mysql-server ca-certificates
 RUN /etc/init.d/mysql start && mysql -u root --password="default" -e "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1'); DELETE FROM mysql.user WHERE User=''; DELETE FROM mysql.db WHERE Db='test' OR Db='test\_%'; FLUSH PRIVILEGES;"
 RUN git clone https://github.com/rathena/rathena.git /rathena && cd /rathena && git checkout $version
 


### PR DESCRIPTION
Resolves issue that occurs when building default docker image, `./configure` fails to complete due to missing libraries (gcc and g++).

**Results after running `./deploy.sh` (without deploying)**
- **Before:**
![image](https://user-images.githubusercontent.com/7020503/80138967-0d958b80-85e9-11ea-8671-3c680cdba0a7.png)
- **After:**
![image](https://user-images.githubusercontent.com/7020503/80139745-4a15b700-85ea-11ea-8a75-1ca01477ca9d.png)
